### PR TITLE
[FEATURE] Proxy request to integration API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,4 +15,4 @@ Layout/LineLength:
 Metrics/BlockLength:
   Enabled: true
   Exclude:
-    - 'spec/**/*_spec.rb' # Exclude block length check for spec files
+    - 'spec/**/*_spec.rb'

--- a/lib/use_paragon/workflow.rb
+++ b/lib/use_paragon/workflow.rb
@@ -5,6 +5,7 @@ require "use_paragon/base"
 module UseParagon
   # https://docs.useparagon.com/workflows/triggers#request
   class Workflow < Base
+    VALID_HTTP_METHODS = %w[post get put patch delete].freeze
     # The Request trigger can be used to run workflows by sending it an HTTP request
     def request(workflow_id, payload = {})
       endpoint = path("sdk/triggers/#{workflow_id}")
@@ -12,16 +13,20 @@ module UseParagon
       connection.post(endpoint, payload)
     end
 
-    # Call request to send an API request to a third-party integration on behalf of
+    # Call proxy_request to send an API request to a third-party integration on behalf of
     # one of your users
-    # https://docs.useparagon.com/api/api-reference#request-integrationtype-string-path-string-requestoptions-requestinit-promise-less-than-unknown-gre
-    # ptions: Request options to include, such as:
-    # body: An object representing JSON contents of the request.
-    # method: An HTTP verb such as "GET" or "POST". Defaults to GET.
-    def proxy_request(integration_type, third_party_path, options)
-      endpoint = path("sdk/proxy/#{integration_type}/#{third_party_path}")
+    # https://docs.useparagon.com/api/making-api-requests#server-side-usage
+    # This endpoint accepts any HTTP verb you want to use with the API:
+    # post, get, put, patch or delete.
+    # Body contents must be specified as application/json.
+    def proxy_request(request_method, integration_type, integration_path, payload = {})
+      formatted_method = request_method&.downcase
 
-      connection.post(endpoint, options)
+      validate_proxy_http_method(formatted_method)
+
+      endpoint = path("sdk/proxy/#{integration_type}/#{integration_path}")
+
+      connection.send(formatted_method, endpoint, payload)
     end
 
     # App Events can be sent from your application using the Paragon REST API.
@@ -45,6 +50,14 @@ module UseParagon
         name: event_name,
         payload: payload
       }
+    end
+
+    def validate_proxy_http_method(formatted_method)
+      return if VALID_HTTP_METHODS.include?(formatted_method)
+
+      raise ArgumentError,
+            "Invalid request method: #{formatted_method}. "  \
+            "Allowed methods: #{VALID_HTTP_METHODS.join(", ")}"
     end
   end
 end

--- a/spec/use_paragon/workflow_spec.rb
+++ b/spec/use_paragon/workflow_spec.rb
@@ -13,11 +13,34 @@ RSpec.describe UseParagon::Workflow do
   end
 
   describe "#proxy_request" do
-    it "calls the correct endpoint with post method" do
-      expect(workflow).to receive(:path).with("sdk/proxy/some_type/some_path")
-                                        .and_return("/projects/123/sdk/proxy/some_type/some_path")
-      expect(workflow).to receive(:connection).and_return(double("connection", post: true))
-      workflow.proxy_request("some_type", "some_path", {})
+    context "with valid HTTP method" do
+      it "calls the correct endpoint with post method" do
+        expect(workflow).to receive(:path).with("sdk/proxy/some_type/some_path")
+                                          .and_return("/projects/123/sdk/proxy/some_type/some_path")
+        expect(workflow).to receive(:connection).and_return(double("connection", post: true))
+        workflow.proxy_request("post", "some_type", "some_path", {})
+      end
+
+      it "calls the correct endpoint with delete method" do
+        expect(workflow).to receive(:path).with("sdk/proxy/some_type/some_path")
+                                          .and_return("/projects/123/sdk/proxy/some_type/some_path")
+        expect(workflow).to receive(:connection).and_return(double("connection", delete: true))
+        workflow.proxy_request("delete", "some_type", "some_path", {})
+      end
+    end
+
+    context "with invalid HTTP method" do
+      it "raises ArgumentError" do
+        expect { workflow.proxy_request("invalid_method", "some_type", "some_path", {}) }
+          .to raise_error(ArgumentError, /Invalid request method/)
+      end
+    end
+
+    context "with missing HTTP method" do
+      it "raises ArgumentError" do
+        expect { workflow.proxy_request(nil, "some_type", "some_path", {}) }
+          .to raise_error(ArgumentError, /Invalid request method/)
+      end
     end
   end
 


### PR DESCRIPTION
# What changed
If you'd like to issue a request from your server to an integration on behalf of an end-user, you can make a request to:
`/projects/<Project ID>/sdk/proxy/<Integration Type>/<API Path>`
or 
`/projects/<Project ID>/sdk/proxy/custom/<Integration ID>/<API Path>`
- A Bearer token must also be specified with a Paragon User Token.
- This endpoint accepts any HTTP verb you want to use with the API.
- Body contents must be specified as application/json.

```js
// POST https://api.useparagon.com/projects/19d...012/sdk/proxy/slack/chat.postMessage

// Authorization: Bearer eyJ...
// Content-Type: application/json

{ 
    "channel": "CXXXXXXX0", 
    "text": "This message was sent with Paragon Connect :exploding_head:" 
}
```